### PR TITLE
Add better logging for cache hits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const subgraphName = require("../package.json").name;
 import { DataSourceContext } from "./types/DataSourceContext";
 import API from "./api";
 import { buildSubgraphSchema } from "@apollo/subgraph";
+import { parse, print } from "graphql";
 
 const context: ContextFunction<
   [StandaloneServerContextFunctionArgument],
@@ -35,7 +36,22 @@ async function main() {
       ApolloServerPluginCacheControl({ defaultMaxAge: 86400 }),
       responseCachePlugin({
         shouldWriteToCache: async (requestContext) => {
-          console.log(JSON.stringify(requestContext));
+          if (
+            requestContext.operationName != "IntrospectionQuery" &&
+            !requestContext.operationName
+              .toLowerCase()
+              .includes("introspection")
+          ){
+            console.log(
+              `Hash: ${requestContext.queryHash}\n\tAge: ${
+                requestContext.overallCachePolicy.maxAge
+              }\n\tOperation: ${
+                requestContext.source.replaceAll("\n","").replaceAll("\t","")
+              }\n\tVariables: ${JSON.stringify(
+                requestContext.request.variables
+              )}`
+            );
+          }
           return false;
         },
       }),


### PR DESCRIPTION
We have the response cache disabled because we thing that is what caused our large memory spike over time (~2 months). It's easy to restart the server to bring the memory down, but we have fairly static requests and we should be able to have a fixed size cache assuming we build the proper cache hashes for operations. 

We'll keep track of the logs and see if we can find common operation shapes that have differences in variable usage or other factors. Maybe we need to just start stripping away operation name 🤔